### PR TITLE
Fix compile error on GCC6 or later.

### DIFF
--- a/include/boost/integer/integer_mask.hpp
+++ b/include/boost/integer/integer_mask.hpp
@@ -63,7 +63,7 @@ struct low_bits_mask_t
     typedef typename uint_t<Bits>::least  least;
     typedef typename uint_t<Bits>::fast   fast;
 
-    BOOST_STATIC_CONSTANT( least, sig_bits = (~( ~(least( 0u )) << Bits )) );
+    BOOST_STATIC_CONSTANT( least, sig_bits = (~(least(~(least( 0u ))) << Bits )) );
     BOOST_STATIC_CONSTANT( fast, sig_bits_fast = fast(sig_bits) );
 
     BOOST_STATIC_CONSTANT( std::size_t, bit_count = Bits );


### PR DESCRIPTION
Bitwise not yields integral promotion and to be signed type.

This PR will fix [Flast-FreeBSD10-gcc-6.1.1~gnu++11 - integer - integer_mask_include_test / gcc-6.1.1](http://www.boost.org/development/tests/develop/developer/output/Flast-FreeBSD10-gcc-6-1-1~gnu++11-boost-bin-v2-libs-integer-test-integer_mask_include_test-test-gcc-6-1-1-debug.html) and many other failure.

Tested on: GCC 6.1.1-20160711(gnu++98,11,14) and clang 3.8.0(gnu++98,11,14).
