### PR TITLE
Enable Boost.Multiprecision tests on gcc 4.7 in C++11 mode.

### DIFF
--- a/test/multiprecision_config.hpp
+++ b/test/multiprecision_config.hpp
@@ -10,8 +10,7 @@
 #include <boost/config.hpp>
 
 #if (defined(BOOST_MSVC) && (BOOST_MSVC < 1500)) || \
-    (defined(__clang_major__) && (__clang_major__ == 3) && (__clang_minor__ < 2)) || \
-    (defined(BOOST_GCC) && defined(BOOST_GCC_CXX11) && BOOST_GCC < 40800)
+    (defined(__clang_major__) && (__clang_major__ == 3) && (__clang_minor__ < 2))
 #define DISABLE_MP_TESTS
 #endif
 


### PR DESCRIPTION
This is to test the compiler in CI.