### PR TITLE
Add minimal cmake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,20 @@ matrix:
     - env: BOGUS_JOB=true
 
   include:
+    # cmake self-test
+    - os: linux
+      env: TEST_CMAKE=TRUE #Only for easier identification in travis web gui
+      install:
+        - git clone --depth 1 https://github.com/boostorg/assert.git ../assert
+        - git clone --depth 1 https://github.com/boostorg/config.git ../config
+        - git clone --depth 1 https://github.com/boostorg/core.git ../core
+        - git clone --depth 1 https://github.com/boostorg/assert.git ../static_assert
+
+      script:
+        - mkdir __build__ && cd __build__
+        - cmake ../test/test_cmake
+        - cmake --build .
+
     - os: linux
       env: TOOLSET=gcc COMPILER=g++ CXXSTD=03
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - git clone --depth 1 https://github.com/boostorg/assert.git ../assert
         - git clone --depth 1 https://github.com/boostorg/config.git ../config
         - git clone --depth 1 https://github.com/boostorg/core.git ../core
-        - git clone --depth 1 https://github.com/boostorg/assert.git ../static_assert
+        - git clone --depth 1 https://github.com/boostorg/static_assert.git ../static_assert
 
       script:
         - mkdir __build__ && cd __build__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.5)
 project(BoostInteger LANGUAGES CXX)
 
 add_library(boost_integer INTERFACE)
-add_library(Boost::boost_integer ALIAS boost_integer)
+add_library(Boost::integer ALIAS boost_integer)
 
 target_include_directories(boost_integer INTERFACE include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Integer is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required(VERSION 3.5)
+
+project(BoostInteger LANGUAGES CXX)
+
+add_library(boost_integer INTERFACE)
+add_library(Boost::boost_integer ALIAS boost_integer)
+
+target_include_directories(boost_integer INTERFACE include)
+
+target_link_libraries(boost_integer
+    INTERFACE
+        Boost::assert
+        Boost::config
+        Boost::core
+        Boost::static_assert
+)
+

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: This does NOT run the unit tests for Boost.Integer.
+#       It only tests, if the CMakeLists.txt file in it's root works as expected
+
+cmake_minimum_required( VERSION 3.5 )
+
+project( BoostIntegerCMakeSelfTest )
+
+add_subdirectory( ../../../assert ${CMAKE_CURRENT_BINARY_DIR}/libs/assert )
+add_subdirectory( ../../../config ${CMAKE_CURRENT_BINARY_DIR}/libs/config )
+add_subdirectory( ../../../core ${CMAKE_CURRENT_BINARY_DIR}/libs/core )
+add_subdirectory( ../../../static_assert ${CMAKE_CURRENT_BINARY_DIR}/libs/static_assert )
+
+add_subdirectory( ../.. ${CMAKE_CURRENT_BINARY_DIR}/libs/boost_integer )
+
+add_executable( boost_integer_cmake_self_test main.cpp )
+target_link_libraries( boost_integer_cmake_self_test Boost::integer )
+

--- a/test/test_cmake/main.cpp
+++ b/test/test_cmake/main.cpp
@@ -1,0 +1,5 @@
+#include <boost/integer.hpp>
+
+int main() {
+
+}


### PR DESCRIPTION
Allows the integration of a local Boost.Integer copy into a cmake project via `add_subdirectory( libs/integer )`