### PR TITLE
lcm_range bug fix

### DIFF
--- a/include/boost/integer/common_factor_rt.hpp
+++ b/include/boost/integer/common_factor_rt.hpp
@@ -524,7 +524,7 @@ lcm_range(I first, I last) BOOST_GCD_NOEXCEPT(I)
     typedef typename std::iterator_traits<I>::value_type T;
     
     T d = *first++;
-    while (d != T(1) && first != last)
+    while (first != last)
     {
         d = lcm(d, *first);
         first++;


### PR DESCRIPTION
Iteration should not stop when encountering an element with a value of 1.
lcm_range of 1,4 should return 4.