### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -7,12 +7,12 @@ import project ;
 
 project /boost/integer
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,25 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/integer
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_integer ]
+    [ alias all : boost_integer test ]
+    ;
+
+call-if : boost-library integer
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/integer
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -5,21 +5,24 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/integer
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_integer ]
+    [ alias boost_integer : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_integer test ]
     ;
 
 call-if : boost-library integer
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/integer

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -7,7 +7,8 @@ import-search /boost/config/checks ;
 import config : requires ;
 import testing ;
 
-project : requirements <warnings>all <toolset>gcc:<cxxflags>-Wextra ;
+project : requirements <warnings>all <toolset>gcc:<cxxflags>-Wextra
+    <library>/boost/integer//boost_integer ;
 
 obj has_gmpxx : has_gmpxx.cpp ;
 explicit has_gmpxx ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -2,8 +2,10 @@
 #~ Distributed under the Boost Software License, Version 1.0.
 #~ (See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+import config : requires ;
 import testing ;
-import ../../config/checks/config : requires ;
 
 project : requirements <warnings>all <toolset>gcc:<cxxflags>-Wextra ;
 
@@ -13,18 +15,18 @@ explicit has_gmpxx ;
 test-suite integer
     :
         [ run integer_traits_test.cpp ]
-        [ run integer_test.cpp : : : <toolset>gcc:<cxxflags>-Wno-long-long <toolset>darwin:<cxxflags>-Wno-long-long <toolset>sun:<cxxflags>"-Qoption ccfe -tmpldepth=128" ]
-        [ run integer_mask_test.cpp ]
-        [ run integer_log2_test.cpp ]
-        [ run static_log2_test.cpp ]
-        [ run static_min_max_test.cpp ]
-        [ run extended_euclidean_test.cpp ]
-        [ run mod_inverse_test.cpp ]
+        [ run integer_test.cpp : : : <library>/boost/mpl//boost_mpl <toolset>gcc:<cxxflags>-Wno-long-long <toolset>darwin:<cxxflags>-Wno-long-long <toolset>sun:<cxxflags>"-Qoption ccfe -tmpldepth=128" ]
+        [ run integer_mask_test.cpp : : : <library>/boost/detail//boost_detail ]
+        [ run integer_log2_test.cpp : : : <library>/boost/multiprecision//boost_multiprecision ]
+        [ run static_log2_test.cpp : : : <library>/boost/detail//boost_detail ]
+        [ run static_min_max_test.cpp : : : <library>/boost/detail//boost_detail ]
+        [ run extended_euclidean_test.cpp : : : <library>/boost/multiprecision//boost_multiprecision ]
+        [ run mod_inverse_test.cpp : : : <library>/boost/optional//boost_optional <library>/boost/multiprecision//boost_multiprecision ]
         [ compile integer_traits_include_test.cpp ]
         [ compile integer_include_test.cpp ]
         [ compile integer_mask_include_test.cpp ]
         [ compile static_log2_include_test.cpp ]
-        [ compile static_min_max_include_test.cpp ]
+        [ compile static_min_max_include_test.cpp : <library>/boost/detail//boost_detail ]
         [ compile integer_fwd_include_test.cpp ]
         [ compile gcd_constexpr14_test.cpp ]
         [ compile gcd_noexcept_test.cpp ]
@@ -35,5 +37,5 @@ test-suite integer
         [ compile-fail fail_uint_fast.cpp ]
         [ compile-fail fail_uint_least.cpp ]
         [ compile-fail fail_uint_65.cpp ]
-        [ run common_factor_test.cpp : : : [ check-target-builds has_gmpxx "Checking for gmpxx.h" : <define>BOOST_INTEGER_HAS_GMPXX_H=1 <linkflags>-lgmp <linkflags>-lgmpxx ] ]
+        [ run common_factor_test.cpp : : : <library>/boost/mpl//boost_mpl <library>/boost/random//boost_random <library>/boost/rational//boost_rational <library>/boost/multiprecision//boost_multiprecision [ check-target-builds has_gmpxx "Checking for gmpxx.h" : <define>BOOST_INTEGER_HAS_GMPXX_H=1 <linkflags>-lgmp <linkflags>-lgmpxx ] ]
     ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.